### PR TITLE
Add Streamlit interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,18 +78,25 @@ A lightweight web interface built with Flask that lets users enter weather featu
 ### 📦 Step 1: Install Requirements
 
 ```bash
-pip install flask pandas scikit-learn joblib
+pip install -r requirements.txt
 ```
 
-### ▶️ Step 2: Run the Web App
+### ▶️ Step 2: Run the Flask Web App
 
 ```bash
 python app.py
 ```
 
-### 🌐 Step 3: Open in Browser
+### ▶️ Step 3: Run the Streamlit App
 
-Go to: [http://127.0.0.1:5000](http://127.0.0.1:5000)
+```bash
+streamlit run streamlit_app.py
+```
+
+### 🌐 Step 4: Open in Browser
+
+For the Flask app, visit [http://127.0.0.1:5000](http://127.0.0.1:5000).
+The Streamlit app typically opens automatically at [http://localhost:8501](http://localhost:8501).
 
 ---
 
@@ -106,6 +113,7 @@ Go to: [http://127.0.0.1:5000](http://127.0.0.1:5000)
 - **Pandas**, **Scikit-learn** (ML & preprocessing)
 - **Matplotlib**, **Seaborn** (visualizations)
 - **Flask** (web framework)
+- **Streamlit** (interactive UI)
 - **Joblib** (model serialization)
 
 ---

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ numpy
 scikit-learn
 joblib
 pandas
+streamlit

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -1,0 +1,27 @@
+import streamlit as st
+import joblib
+import pandas as pd
+
+# Load trained model
+model = joblib.load("wildfire_model.pkl")
+
+# Input features expected by the model
+FEATURES = ['FFMC', 'DMC', 'DC', 'ISI', 'temp', 'RH', 'wind', 'rain']
+
+def main():
+    st.title("Wildfire Risk Prediction")
+    st.write("Enter the weather parameters below to estimate wildfire risk.")
+
+    # Collect user input
+    user_input = {}
+    for feature in FEATURES:
+        user_input[feature] = st.number_input(feature, value=0.0)
+
+    if st.button("Predict"):
+        input_df = pd.DataFrame([user_input])
+        prediction = model.predict(input_df)[0]
+        label = "🔥 High Risk" if prediction == 1 else "✅ Low Risk"
+        st.success(f"Wildfire Risk: {label}")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a simple Streamlit app to load the wildfire model
- document how to launch the Streamlit UI
- include Streamlit in project requirements

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6856d30f8d80832592297ac32f50238f